### PR TITLE
fix: handle window destruction in inactive workspaces

### DIFF
--- a/src/event_handler/winevent.rs
+++ b/src/event_handler/winevent.rs
@@ -12,11 +12,13 @@ mod show;
 pub fn handle(ev: WinEvent) -> Result<(), Box<dyn std::error::Error>> {
     let grids = GRIDS.lock().unwrap();
     let mut title: Option<String> = None;
+    let mut grid_id: Option<i32> = None;
 
     for grid in grids.iter() {
         for tile in &grid.tiles {
             if tile.window.id == ev.hwnd {
                 title = Some(tile.window.title.clone());
+                grid_id = Some(grid.id);
                 break;
             }
         }
@@ -38,7 +40,7 @@ pub fn handle(ev: WinEvent) -> Result<(), Box<dyn std::error::Error>> {
     drop(grids);
 
     match ev.typ {
-        WinEventType::Destroy => destroy::handle(ev.hwnd as HWND)?,
+        WinEventType::Destroy => destroy::handle(ev.hwnd as HWND, grid_id)?,
         WinEventType::Show(ignore) => show::handle(ev.hwnd as HWND, ignore)?,
         WinEventType::FocusChange => focus_change::handle(ev.hwnd as HWND)?,
         WinEventType::Hide => {}

--- a/src/event_handler/winevent/destroy.rs
+++ b/src/event_handler/winevent/destroy.rs
@@ -2,11 +2,12 @@ use crate::GRIDS;
 use crate::WORKSPACE_ID;
 use winapi::shared::windef::HWND;
 
-pub fn handle(hwnd: HWND) -> Result<(), Box<dyn std::error::Error>> {
+pub fn handle(hwnd: HWND, grid_id: Option<i32>) -> Result<(), Box<dyn std::error::Error>> {
     let mut grids = GRIDS.lock().unwrap();
+    let grid_id = grid_id.unwrap_or(*WORKSPACE_ID.lock().unwrap());
     let grid = grids
         .iter_mut()
-        .find(|g| g.id == *WORKSPACE_ID.lock().unwrap())
+        .find(|g| g.id == grid_id)
         .unwrap();
 
     if grid.close_tile_by_window_id(hwnd as i32).is_some() {


### PR DESCRIPTION
Addresses issue #82 by modifying the window destroy handler to take a grid_id associated with the destroyed window and falling back on the active grid_id if None is passed in.