### PR TITLE
[WIP] Fix: #253 clicking tile should trigger redraw

### DIFF
--- a/book/src/api/nog/bind.md
+++ b/book/src/api/nog/bind.md
@@ -21,6 +21,6 @@ fn bind(key_combo: String, callback: (), kind: KeybindingKind?) -> Void
 ## Example
 
 ```nogscript
- nog.bind("F1", () => print("Hello World"))
+ nog.bind("F1", () => print("Hello World"), "global")
 ```
 

--- a/book/src/api/nog/bind_arr.md
+++ b/book/src/api/nog/bind_arr.md
@@ -22,6 +22,6 @@ fn bind_arr(modifier: String, callback: (), arr: Any[], always_active: Keybindin
 ## Example
 
 ```nogscript
- nog.bind_arr("Alt", nog.workspace.change, range(10))
+ nog.bind_arr("Alt", nog.workspace.change, range(10), "work")
 ```
 

--- a/book/src/api/nog/bind_map.md
+++ b/book/src/api/nog/bind_map.md
@@ -27,6 +27,6 @@ fn bind_map(modifier: String, callback: (), map: Map<String,, always_active: Key
    "J": "Down",
    "K": "Up",
    "L": "Right"
- })
+ }, "work")
 ```
 

--- a/twm/src/display.rs
+++ b/twm/src/display.rs
@@ -146,6 +146,9 @@ impl Display {
     /// Returns true if the workspace was found and false if it wasn't
     pub fn focus_workspace(&mut self, config: &Config, id: i32) -> SystemResult<bool> {
         if let Some(grid) = self.get_grid_by_id_mut(id) {
+            if grid.fullscreen_id.is_some() {
+                grid.focused_id = grid.fullscreen_id;
+            }
             if !grid.focused_id.is_some() {
                 grid.focus_last_tile(); // ensures a tile is focused on the current grid
             }

--- a/twm/src/event_handler/winevent/destroy.rs
+++ b/twm/src/event_handler/winevent/destroy.rs
@@ -9,7 +9,7 @@ pub fn handle(
         .find_grid_containing_window(window.id)
         .map(|g| g.remove_by_window_id(window.id))
     {
-        state.get_current_display().refresh_grid(&state.config)?;
+        state.refresh_visible_grids()?;
     }
     Ok(())
 }

--- a/twm/src/event_handler/winevent/focus_change.rs
+++ b/twm/src/event_handler/winevent/focus_change.rs
@@ -4,7 +4,7 @@ pub fn handle(state: &mut AppState, window: NativeWindow) -> SystemResult {
     if let Some(g) = state.find_grid_containing_window(window.id) {
         g.focus_tile_by_window_id(window.id);
         state.workspace_id = g.id;
-        state.refresh_visible_grids()?;
+        state.refresh_current_grid()?;
     }
 
     Ok(())

--- a/twm/src/event_handler/winevent/focus_change.rs
+++ b/twm/src/event_handler/winevent/focus_change.rs
@@ -4,6 +4,7 @@ pub fn handle(state: &mut AppState, window: NativeWindow) -> SystemResult {
     if let Some(g) = state.find_grid_containing_window(window.id) {
         g.focus_tile_by_window_id(window.id);
         state.workspace_id = g.id;
+        state.refresh_visible_grids()?;
     }
 
     Ok(())

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -796,6 +796,14 @@ impl AppState {
             .map(|d| d.refresh_grid(&config))
             .collect::<Result<(), SystemError>>()
     }
+
+    pub fn refresh_current_grid(&mut self) -> SystemResult {
+        let config = self.config.clone();
+        let display = self.get_current_display_mut();
+        display.refresh_grid(&config)?;
+
+        Ok(())
+    }
 }
 
 fn on_quit(state: &mut AppState) -> SystemResult {


### PR DESCRIPTION
- added lines to refresh all grids, not just ones on the focused monitor
- added missing updates of the grid file when moving workspaces