### PR TITLE
[WIP] Dpi scaling, resolution changes and multimonitor support

### DIFF
--- a/twm/Cargo.toml
+++ b/twm/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 syn = "1.0.38"
 flexi_logger = "0.15"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
-winapi = { version = "0.3", features = ["winuser", "errhandlingapi", "impl-default", "shellapi", "windowsx", "shellscalingapi", "processthreadsapi", "psapi"] }
+winapi = { version = "0.3", features = ["winuser", "errhandlingapi", "impl-default", "shellapi", "windowsx", "shellscalingapi", "processthreadsapi", "psapi", "dwmapi"] }
 serde = "1.0"
 serde_json = "1.0"
 chrono = "0.4"

--- a/twm/src/bar.rs
+++ b/twm/src/bar.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{system::DisplayId, window::Window, AppState};
 use item::Item;
-use crate::{SystemResult, SystemError};
+use crate::{SystemResult, SystemError, util};
 use item_section::ItemSection;
 use parking_lot::Mutex;
 
@@ -49,14 +49,10 @@ impl Bar {
     
     pub fn change_height(&self, height: i32) -> SystemResult {
         let nwin = self.window.get_native_window();
+        let display = nwin.get_display().unwrap();
         let mut rect = nwin.get_rect()?;
-
-        if rect.top == 0 {
-            rect.bottom = height;
-        } else {
-            rect.top = rect.bottom - height;
-        }
-
+        let height = util::points_to_pixels(height, &display);
+        rect.bottom = rect.top + height;
         nwin.set_window_pos(rect, None, None).map_err(|e| SystemError::Unknown(e))
     }
 }

--- a/twm/src/bar/create.rs
+++ b/twm/src/bar/create.rs
@@ -176,21 +176,18 @@ pub fn create_or_update(state_arc: Arc<Mutex<AppState>>) {
 
         bar.window.create(state_arc.clone(), true, move |event| {
             match event {
-                WindowEvent::Native {
+                WindowEvent::AppBar {
                     msg, display_id, ..
                 } => {
                     //TODO: make this cleaner
                     #[cfg(target_os = "windows")]
                     {
                         use winapi::um::shellapi::ABN_FULLSCREENAPP;
-                        use winapi::um::winuser::WM_APP;
 
-                        if msg.code == WM_APP + 1 {
-                            if msg.params.0 == ABN_FULLSCREENAPP as usize {
-                                sender
-                                    .send(Event::ToggleAppbar(*display_id))
-                                    .expect("Failed to send ToggleAppbar event");
-                            }
+                        if msg.params.0 == ABN_FULLSCREENAPP as usize {
+                            sender
+                                .send(Event::ToggleAppbar(*display_id))
+                                .expect("Failed to send ToggleAppbar event");
                         }
                     }
                 }

--- a/twm/src/bar/create.rs
+++ b/twm/src/bar/create.rs
@@ -121,7 +121,7 @@ fn clear_section(api: &Api, config: &Config, left: i32, right: i32, display: &Di
     api.fill_rect(left, 0, right - left, height, config.bar.color)
 }
 
-pub fn create(state_arc: Arc<Mutex<AppState>>) {
+pub fn create_or_update(state_arc: Arc<Mutex<AppState>>) {
     info!("Creating appbar");
 
     let sender = state_arc
@@ -143,11 +143,9 @@ pub fn create(state_arc: Arc<Mutex<AppState>>) {
             .config
             .clone();
 
-        if display.appbar.is_some() {
-            error!(
-                "Appbar for monitor {:?} already exists. Aborting",
-                display.id
-            );
+        if let Some(existing_bar) = display.appbar {
+            // Change height of existing bars in case the display has changed
+            existing_bar.change_height(config.bar.height);
             continue;
         }
 

--- a/twm/src/display.rs
+++ b/twm/src/display.rs
@@ -8,6 +8,7 @@ use crate::{
     task_bar,
     tile_grid::store::Store,
     tile_grid::TileGrid,
+    util,
 };
 use std::cmp::Ordering;
 use task_bar::{Taskbar, TaskbarPosition};
@@ -69,7 +70,7 @@ impl Display {
         self.height()
             - if config.remove_task_bar { 0 } else { tb_height }
             - if config.display_app_bar {
-                config.bar.height
+                util::points_to_pixels(config.bar.height, &self)
             } else {
                 0
             }
@@ -102,7 +103,7 @@ impl Display {
 
         self.rect.top
             + if config.display_app_bar {
-                config.bar.height
+                util::points_to_pixels(config.bar.height, &self) 
             } else {
                 0
             }

--- a/twm/src/hot_reload.rs
+++ b/twm/src/hot_reload.rs
@@ -95,7 +95,7 @@ pub fn update_config(state_arc: Arc<Mutex<AppState>>, new_config: Config) -> Sys
 
     if draw_app_bar {
         drop(state);
-        bar::create::create(state_arc.clone());
+        bar::create::create_or_update(state_arc.clone());
         state = state_arc.lock();
     }
 

--- a/twm/src/lua/mod.rs
+++ b/twm/src/lua/mod.rs
@@ -467,7 +467,7 @@ fn setup_nog_global(state_arc: Arc<Mutex<AppState>>, rt: &LuaRuntime) {
                             }
 
                             if new {
-                                for d in crate::display::init(&state.config) {
+                                for d in crate::display::init(&state.config, None) {
                                     if !d.is_primary() {
                                         state.displays.push(d);
                                     }

--- a/twm/src/lua/mod.rs
+++ b/twm/src/lua/mod.rs
@@ -543,6 +543,7 @@ fn setup_nog_global(state_arc: Arc<Mutex<AppState>>, rt: &LuaRuntime) {
                                     bar.change_height(new)?;
                                 }
                             }
+                            state.redraw();
                         }
                         Ok(())
                     }),

--- a/twm/src/main.rs
+++ b/twm/src/main.rs
@@ -30,7 +30,6 @@ use task_bar::Taskbar;
 use tile_grid::{store::Store, TileGrid};
 use win_event_handler::{win_event::WinEvent, win_event_type::WinEventType};
 use window::Window;
-
 pub const NOG_BAR_NAME: &'static str = "nog_bar";
 pub const NOG_POPUP_NAME: &'static str = "nog_popup";
 
@@ -1173,6 +1172,8 @@ fn run_config(rt: &LuaRuntime) {
 fn main() {
     std::env::set_var("RUST_BACKTRACE", "1");
     logging::setup().expect("Failed to setup logging");
+
+    crate::system::api::enable_high_dpi().expect("Failed to enable high dpi mode");
 
     info!("Config: {:?}", get_config_path());
     info!("Runtime: {:?}", get_runtime_path());

--- a/twm/src/system/mod.rs
+++ b/twm/src/system/mod.rs
@@ -94,6 +94,8 @@ pub enum SystemError {
     UnregisterKeybinding { key: String, os_error: String },
     #[error("An error that is specific to the platform occured")]
     Native(#[from] SpecificError),
+    #[error("Failed to enable high dpi mode")]
+    DpiScaling(),
     #[error("An unknown error occured")]
     Unknown(SpecificError),
 }

--- a/twm/src/system/win/api.rs
+++ b/twm/src/system/win/api.rs
@@ -82,7 +82,7 @@ pub fn get_display_dpi(id: DisplayId) -> u32 {
     let mut dpi_y: u32 = 0;
 
     unsafe {
-        GetDpiForMonitor(id.into(), MDT_RAW_DPI, &mut dpi_x, &mut dpi_y);
+        GetDpiForMonitor(id.into(), MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
     }
 
     dpi_x

--- a/twm/src/system/win/api.rs
+++ b/twm/src/system/win/api.rs
@@ -14,10 +14,10 @@ use crate::{
 use log::{debug, error};
 use regex::Regex;
 use winapi::{
-    shared::{minwindef::*, windef::*},
+    shared::{minwindef::*, windef::*, winerror::*},
     um::{
         errhandlingapi::*, processthreadsapi::*, shellscalingapi::*, winbase::*, winnt::*,
-        winreg::*, winuser::*,
+        winreg::*, winuser::*, shellscalingapi::*,
     },
 };
 
@@ -257,5 +257,16 @@ pub fn launch_program(cmd: String) -> SystemResult {
         } else {
             Ok(())
         }
+    }
+}
+
+pub fn enable_high_dpi() -> SystemResult {
+    let res = unsafe { 
+        SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)
+    };
+    if (SUCCEEDED(res)) {
+        Ok(())
+    } else {
+        Err(SystemError::DpiScaling())
     }
 }

--- a/twm/src/system/win/menu.rs
+++ b/twm/src/system/win/menu.rs
@@ -32,6 +32,7 @@ enum WindowCommand {
     Created = (WM_APP + 1) as isize,
     InputChanged,
     LostFocus,
+    AppBar,
 }
 
 unsafe extern "system" fn window_cb(

--- a/twm/src/task_bar.rs
+++ b/twm/src/task_bar.rs
@@ -1,4 +1,5 @@
 use crate::system::NativeWindow;
+use crate::system::win::WinResult;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TaskbarPosition {
@@ -29,37 +30,35 @@ impl Taskbar {
         }
     }
 
-    pub fn get_position(&self) -> TaskbarPosition {
+    pub fn get_position(&self) -> WinResult<TaskbarPosition> {
         let tb_rect = self
             .window
-            .get_rect()
-            .expect("Failed to get rect of taskbar window");
+            .get_rect()?;
 
         let display_rect = self
             .window
-            .get_display()
-            .expect("Failed to get display of taskbar")
+            .get_display()?
             .rect;
 
         if self.window.is_hidden() {
-            TaskbarPosition::Hidden
+            Ok(TaskbarPosition::Hidden)
         } else if tb_rect.left == display_rect.left
             && tb_rect.top == display_rect.top
             && tb_rect.bottom == display_rect.bottom
         {
-            TaskbarPosition::Left
+            Ok(TaskbarPosition::Left)
         } else if tb_rect.right == display_rect.right
             && tb_rect.top == display_rect.top
             && tb_rect.bottom == display_rect.bottom
         {
-            TaskbarPosition::Right
+            Ok(TaskbarPosition::Right)
         } else if tb_rect.left == display_rect.left
             && tb_rect.top == display_rect.top
             && tb_rect.right == display_rect.right
         {
-            TaskbarPosition::Top
+            Ok(TaskbarPosition::Top)
         } else {
-            TaskbarPosition::Bottom
+            Ok(TaskbarPosition::Bottom)
         }
     }
 }

--- a/twm/src/tile_grid.rs
+++ b/twm/src/tile_grid.rs
@@ -8,6 +8,7 @@ use crate::{
     system::SystemError,
     system::SystemResult,
     system::WindowId,
+    util,
     tile_grid::{
         graph_wrapper::GraphWrapper, node::Node, node::NodeInfo, text_renderer::TextRenderer,
         tile_render_info::TileRenderInfo,
@@ -64,6 +65,8 @@ impl TileGrid {
                 0
             },
         );
+        let padding = util::points_to_pixels(padding, &display);
+        let maging = util::points_to_pixels(margin, &display);
 
         let display_width = display.working_area_width(config) - margin;
         let display_height = display.working_area_height(config) - margin;

--- a/twm/src/tray.rs
+++ b/twm/src/tray.rs
@@ -33,6 +33,8 @@ use winapi::{
     um::winuser::WM_COMMAND,
     um::winuser::WM_INITMENUPOPUP,
     um::winuser::WM_RBUTTONUP,
+    um::winuser::WM_DISPLAYCHANGE,
+    um::winuser::WM_DPICHANGED,
 };
 
 pub static WINDOW: Mutex<Option<Window>> = Mutex::new(None);
@@ -55,7 +57,7 @@ pub fn create(state: Arc<Mutex<AppState>>) {
 
     drop(state);
 
-    window.create(state_arc, false, move |event| {
+    window.create(state_arc.clone(), false, move |event| {
         match event {
             WindowEvent::Create { window_id, .. } => {
                 add_icon(window_id.to_owned().into());
@@ -84,6 +86,8 @@ pub fn create(state: Arc<Mutex<AppState>>) {
                         show_popup_menu(msg.hwnd);
                         PostMessageW(msg.hwnd, WM_APP + 1, 0, 0);
                     }
+                } else if msg.code == WM_DISPLAYCHANGE || msg.code == WM_DPICHANGED {
+                    AppState::handle_display_change(state_arc.clone())?;
                 }
             }
             _ => {}

--- a/twm/src/tray.rs
+++ b/twm/src/tray.rs
@@ -35,6 +35,7 @@ use winapi::{
     um::winuser::WM_RBUTTONUP,
     um::winuser::WM_DISPLAYCHANGE,
     um::winuser::WM_DPICHANGED,
+    um::shellapi::ABN_POSCHANGED,
 };
 
 pub static WINDOW: Mutex<Option<Window>> = Mutex::new(None);
@@ -86,7 +87,14 @@ pub fn create(state: Arc<Mutex<AppState>>) {
                         show_popup_menu(msg.hwnd);
                         PostMessageW(msg.hwnd, WM_APP + 1, 0, 0);
                     }
-                } else if msg.code == WM_DISPLAYCHANGE || msg.code == WM_DPICHANGED {
+                } else if
+                    msg.code == WM_DISPLAYCHANGE || msg.code == WM_DPICHANGED {
+                        AppState::handle_display_change(state_arc.clone())?;
+                }
+            }
+            WindowEvent::AppBar {msg, .. } => {
+                 // Taskbar position or size changed
+                if msg.params.0 == ABN_POSCHANGED as usize {
                     AppState::handle_display_change(state_arc.clone())?;
                 }
             }

--- a/twm/src/util.rs
+++ b/twm/src/util.rs
@@ -1,3 +1,6 @@
+use crate::Display;
+use num_traits::{PrimInt, AsPrimitive, FromPrimitive, signum};
+
 pub fn bytes_to_string(buffer: &[i8]) -> String {
     buffer
         .iter()
@@ -28,4 +31,14 @@ pub fn scale_color(color: i32, factor: f64) -> i32 {
     blue = (blue as f64 * factor).round() as i32;
 
     rgb_to_hex((red, green, blue))
+}
+
+pub fn points_to_pixels<T: PrimInt + AsPrimitive<i64> + FromPrimitive>(points: T, display: &Display) -> T {
+    let signed_p: i64 = points.as_();
+    let unsigned_p = signed_p.abs() as u64;
+    const points_per_inch: u64 = 72;
+    let dpi = display.dpi as u64;
+    // Note the (points_per_inch << 1) rounds the result to the nearest integer
+    let res = ((unsigned_p * dpi + (points_per_inch << 1)) / points_per_inch) as i64;
+    FromPrimitive::from_i64(res * signum(signed_p)).unwrap()
 }

--- a/twm/src/window.rs
+++ b/twm/src/window.rs
@@ -103,6 +103,7 @@ impl Api {
         }
     }
     pub fn with_font<T>(&self, name: &str, size: i32, cb: impl Fn() -> RuntimeResult<T>) -> RuntimeResult<T> {
+        let display = self.window.get_display().unwrap();
         unsafe {
             let mut logfont = LOGFONTA::default();
             let mut font_name: [i8; 32] = [0; 32];
@@ -116,7 +117,10 @@ impl Api {
                 font_name[i] = *byte as i8;
             }
 
-            logfont.lfHeight = size;
+            // Note, negative values specifies the actual font size and is consistent with other
+            // programs
+            // Positive values specifies the cell height, so the actual font is slightly smaller
+            logfont.lfHeight = -util::points_to_pixels(size, &display);
             logfont.lfFaceName = font_name;
 
             let font = CreateFontIndirectA(&logfont);


### PR DESCRIPTION
This pull request started by me trying to fix #92. I found out that `DWMWA_EXTENDED_FRAME_BOUNDS`  gives the actual visible window size and position in pixels and the `GetWindowRect` function gives the size including the invisible part. So to position the window correctly, we need to offset the window by the difference between the two values. This seems to work for all different windows I have tried, including firefox and chrome, and both works without any special cases and additionally the problem in #207 is fixed.

But in order to do that, we need to enable per monitor DPI awareness, since `GetWindowRect` returns virtual pixels instead of real pixels, so otherwise the two values are not comparable. That means that we need to convert points to pixels in a few places, so I added the utility function `points_to_pixels`. I also made all size configuration variables use points in pixels, so that they are consistent across monitors and scalings, and are properly relative to the font sizes. For the fonts I changed the size to be negative, which means that you specify the actual font size instead of the bounding rect, which makes the fonts sizes consistent with other programs like notepad. These two changes means that you might have to change your configuration a little bit to make it look like before, but I believe that this way is better and more natural.

One side effect of enabling the per monitor awareness is also that I no longer get the (unreported?) bug where the font of windows titlebars become very small.

This dpi awareness naturally led me to implement support for changing the scaling on the fly. And since changing resolution is closely related I added support for that too. In all cases, when there are some changes, the display arrays are re-created, which avoids the need of too much special case handling. This design naturally led me to support display connects and disconnects as well. For disconnects, if a workspace belongs to a display that's no longer available, it's migrated to the new primary display. If a new display is added, then nothing happens to the workspaces.

There was one complication when implementing this, the taskbar does not react immediately to the new dpi or resolution, so I had to detect taskbar size and position changes, and react to that in the same way as well. And this had the nice side effect that the workspace now correctly updates when resizing or moving the taskbar.

Resolution changes are a little bit more complicated in relation to the taskbar, since many query functions on the taskbar temporarily returns errors, so those errors are now ignored. They don't really matter, since the taskbar position event is sent very quickly after, and at that point the taskbar is valid again, so everything refreshes correctly.

Note that the pull request is still WIP. I need to go through the code, and possibly clean up some things first, this is the first time I write Rust, and I learned a few things when doing this, so I need to clean up the earlier commits. But feel free to give suggestions, I'm still very new to Rust.

Additionally there's still at least one known bug, if you have moved the workspace to another montior, then it will flash between the screens when the monitor size changes. I know the reason, but I haven't fixed it yet, the `focused_grid_id` field of the old display is not cleared.

It also most likely does not handle unplugging all of the monitors, and I'm not actually sure what to do in that case. Perhaps create a virtual display? Or exit the workmode? 

Finally #90 reports that the monitor ids are not stable, so I think the comparison has to use device ids instead. I have personally not run into that issue, but I believe it's there.

fix #90
fix #92
fix #207